### PR TITLE
Restrict `/auth` endpoint to SYSTEM oracle

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const SYSTEM_ORACLE_ID = 1;

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,7 +1,10 @@
+import {authenticate} from '@loopback/authentication';
+import {authorize} from '@loopback/authorization';
 import {service} from '@loopback/core';
 import {repository} from '@loopback/repository';
 import {getModelSchemaRef, post, requestBody, response} from '@loopback/rest';
 import {OracleApiKey} from '../models';
+import {AUTH_STRATEGY_NAME} from '../providers/passport-bearer-auth.provider';
 import {AuthRepository} from '../repositories';
 import {AuthService} from '../services';
 
@@ -11,6 +14,8 @@ export class AuthController {
     @service(AuthService) public authService: AuthService,
   ) {}
 
+  @authenticate(AUTH_STRATEGY_NAME)
+  @authorize({resource: 'auth'})
   @post('/auth')
   @response(200, {
     description: 'OracleApiKey model instance',

--- a/src/models/oracle-api-key.model.ts
+++ b/src/models/oracle-api-key.model.ts
@@ -56,7 +56,7 @@ export class OracleApiKey extends Entity {
       default: false,
     },
   })
-  expired = false;
+  expired: boolean = false;
 }
 
 export interface OracleApiKeyRelations {

--- a/src/providers/oracle-authorization.provider.ts
+++ b/src/providers/oracle-authorization.provider.ts
@@ -7,6 +7,7 @@ import {
 import {Provider} from '@loopback/core';
 import {RequestContext} from '@loopback/rest';
 import {Request} from 'express';
+import {SYSTEM_ORACLE_ID} from '../constants';
 import {GoodOracle} from '../models';
 
 interface AuthorizationCheckParams {
@@ -55,7 +56,7 @@ export class OracleAuthorizationProvider implements Provider<Authorizer> {
         {
           POST: () => {
             // only allow SYSTEM account
-            return oracle.id === 1
+            return oracle.id === SYSTEM_ORACLE_ID
               ? AuthorizationDecision.ALLOW
               : AuthorizationDecision.DENY;
           },
@@ -72,7 +73,7 @@ export class OracleAuthorizationProvider implements Provider<Authorizer> {
 
     if (oracle === undefined) return AuthorizationDecision.ABSTAIN;
     // SYSTEM account
-    if (oracle.id === 1) return AuthorizationDecision.ALLOW;
+    if (oracle.id === SYSTEM_ORACLE_ID) return AuthorizationDecision.ALLOW;
 
     const resource = metadata.resource;
     if (!resource) {

--- a/src/providers/oracle-authorization.provider.ts
+++ b/src/providers/oracle-authorization.provider.ts
@@ -17,6 +17,7 @@ interface AuthorizationCheckParams {
 
 // Class level authorizer
 export class OracleAuthorizationProvider implements Provider<Authorizer> {
+  DEFAULT_AUTH_DECISION = AuthorizationDecision.ALLOW;
   constructor() {}
 
   value(): Authorizer {
@@ -44,7 +45,22 @@ export class OracleAuthorizationProvider implements Provider<Authorizer> {
               return AuthorizationDecision.DENY;
           },
         };
-      return rules[request.method]() ?? AuthorizationDecision.ALLOW;
+      return rules[request.method]() ?? this.DEFAULT_AUTH_DECISION;
+    },
+    auth: ({
+      request,
+      oracle,
+    }: AuthorizationCheckParams): AuthorizationDecision => {
+      const rules: {[method: string]: () => AuthorizationDecision | undefined} =
+        {
+          POST: () => {
+            // only allow SYSTEM account
+            return oracle.id === 1
+              ? AuthorizationDecision.ALLOW
+              : AuthorizationDecision.DENY;
+          },
+        };
+      return rules[request.method]() ?? this.DEFAULT_AUTH_DECISION;
     },
   };
 


### PR DESCRIPTION
### Testing
- Make a POST request (no Authorization header) to `/auth` with body of :
```json
{
  "oracleId": 4
}
```
  - Should receive 401
- Repeat POST request, with Authorization header containing a random string
  - Should receive 401
- Repeat POST request, with Authorization header containing an API key belonging to an oracle with id !== 4 && id !== 1
  - Should receive 403
- Repeat POST request, with Authorization header containing SYSTEM (id = 1) API key
  - Should receive 200 with `OracleApiKey` response body
- Repeat POST request, with Authorization header containing an API key belonging to oracle id === 4
  - Should receive 403