### PR TITLE
refactor(controllers): implement `@api` class-level annotation

### DIFF
--- a/src/controllers/activity.controller.ts
+++ b/src/controllers/activity.controller.ts
@@ -1,6 +1,7 @@
 import {service} from '@loopback/core';
 import {Filter, repository} from '@loopback/repository';
 import {
+  api,
   get,
   getModelSchemaRef,
   HttpErrors,
@@ -8,26 +9,28 @@ import {
   patch,
   post,
   put,
-  requestBody
+  requestBody,
 } from '@loopback/rest';
 import {BigNumber} from 'ethers';
 import {ErrorResponse, GoodActivity} from '../models';
 import {GoodActivityRepository} from '../repositories';
 import {ProofOfGoodSmartContractService} from '../services';
+
+@api({basePath: '/activity'})
 export class ActivityController {
   constructor(
     @repository(GoodActivityRepository)
     public goodActivityRepository: GoodActivityRepository,
     @service(ProofOfGoodSmartContractService)
     private proofOfGoodSmartContractService: ProofOfGoodSmartContractService,
-  ) { }
+  ) {}
 
   /**
    * Create a new Activity
    *
    * @param activity
    */
-  @post('/activity', {
+  @post('/', {
     summary: 'Create an Activity',
     operationId: 'post-activity',
     responses: {
@@ -152,7 +155,7 @@ export class ActivityController {
    * @param id The PoG ID of the Activity
    * @param oracle
    */
-  @patch('/activity/{id}', {
+  @patch('/{id}', {
     summary: 'Change Activity Details',
     operationId: 'put-activity',
     responses: {
@@ -302,7 +305,7 @@ export class ActivityController {
    * @param id The PoG ID of the activity
    * @param activity
    */
-  @put('/activity/{id}', {
+  @put('/{id}', {
     summary: 'Change Activity Details',
     operationId: 'put-activity',
     responses: {
@@ -401,7 +404,7 @@ export class ActivityController {
    * @param id The PoG ID of the activity
    * @returns A Proof of Good Activity
    */
-  @get('/activity/{id}', {
+  @get('/{id}', {
     summary: 'Get Activity',
     operationId: 'get-activity',
     responses: {
@@ -449,7 +452,7 @@ export class ActivityController {
     return this.goodActivityRepository.findById(id);
   }
 
-  @get('/activity', {
+  @get('/', {
     responses: {
       '200': {
         description: 'Retrieve all Proof of Good Activities',

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -2,13 +2,21 @@ import {authenticate} from '@loopback/authentication';
 import {authorize} from '@loopback/authorization';
 import {inject, service} from '@loopback/core';
 import {repository} from '@loopback/repository';
-import {getModelSchemaRef, post, requestBody, response} from '@loopback/rest';
+import {
+  api,
+  getModelSchemaRef,
+  post,
+  requestBody,
+  response,
+} from '@loopback/rest';
 import {SecurityBindings} from '@loopback/security';
 import {GoodOracle, OracleApiKey} from '../models';
 import {AUTH_STRATEGY_NAME} from '../providers/passport-bearer-auth.provider';
 import {AuthRepository} from '../repositories';
 import {AuthService} from '../services';
 
+@api({basePath: '/auth'})
+@authenticate(AUTH_STRATEGY_NAME)
 export class AuthController {
   constructor(
     @repository(AuthRepository) public authRepository: AuthRepository,
@@ -17,9 +25,8 @@ export class AuthController {
     private oracle: GoodOracle,
   ) {}
 
-  @authenticate(AUTH_STRATEGY_NAME)
   @authorize({resource: 'SYSTEM_ONLY'})
-  @post('/auth')
+  @post('/')
   @response(200, {
     description: 'OracleApiKey model instance',
     content: {'application/json': {schema: getModelSchemaRef(OracleApiKey)}},
@@ -47,7 +54,6 @@ export class AuthController {
     return this.authRepository.create(oracleApiKey);
   }
 
-  @authenticate(AUTH_STRATEGY_NAME)
   @post('/refresh')
   @response(200, {
     description: 'OracleApiKey model instance',

--- a/src/controllers/category.controller.ts
+++ b/src/controllers/category.controller.ts
@@ -1,6 +1,7 @@
 import {service} from '@loopback/core';
 import {Filter, repository} from '@loopback/repository';
 import {
+  api,
   get,
   getModelSchemaRef,
   HttpErrors,
@@ -14,6 +15,7 @@ import {ErrorResponse, GoodCategory} from '../models';
 import {GoodCategoryRepository} from '../repositories';
 import {ProofOfGoodSmartContractService} from '../services';
 
+@api({basePath: '/category'})
 export class CategoryController {
   constructor(
     @repository(GoodCategoryRepository)
@@ -28,7 +30,7 @@ export class CategoryController {
    * @param id The PoG ID of the category
    * @param category
    */
-  @post('/category', {
+  @post('/', {
     summary: 'Create a Category',
     operationId: 'post-category',
     responses: {
@@ -125,7 +127,7 @@ export class CategoryController {
     return response;
   }
 
-  @patch('/category/{id}', {
+  @patch('/{id}', {
     summary: 'Change Category Details',
     operationId: 'patch-category',
     responses: {
@@ -256,7 +258,7 @@ export class CategoryController {
    * @param id The PoG ID of the category
    * @param category
    */
-  @put('/category/{id}', {
+  @put('/{id}', {
     summary: 'Change Category Details',
     operationId: 'put-category',
     responses: {
@@ -353,7 +355,7 @@ export class CategoryController {
    * @param id The PoG ID of the category
    * @returns A Proof of Good Category
    */
-  @get('/category/{id}', {
+  @get('/{id}', {
     summary: 'Get Category',
     operationId: 'get-category',
     responses: {
@@ -405,7 +407,7 @@ export class CategoryController {
     return this.goodCategoryRepository.findById(id);
   }
 
-  @get('/category', {
+  @get('/', {
     responses: {
       '200': {
         description: 'Retrieve all Proof of Good Categories',

--- a/src/controllers/entry.controller.ts
+++ b/src/controllers/entry.controller.ts
@@ -1,6 +1,7 @@
 import {service} from '@loopback/core';
 import {Filter, repository} from '@loopback/repository';
 import {
+  api,
   get,
   getModelSchemaRef,
   HttpErrors,
@@ -22,6 +23,8 @@ export type PogProfileParams = {
   email: string;
   doGooder: string;
 };
+
+@api({basePath: '/entry'})
 export class GoodEntryController {
   constructor(
     @repository(GoodEntryRepository)
@@ -40,7 +43,7 @@ export class GoodEntryController {
    * @param id The PoG ID of the entry
    * @returns A Proof of Good Entry
    */
-  @get('/entry/{id}', {
+  @get('/{id}', {
     summary: 'Get Proof of Good Entry',
     operationId: 'get-entry',
     responses: {
@@ -88,7 +91,7 @@ export class GoodEntryController {
     return this.goodEntryRepository.findById(id);
   }
 
-  @get('/entry', {
+  @get('/', {
     responses: {
       '200': {
         description: 'Retrieve all Proof of Good Entries',
@@ -117,7 +120,7 @@ export class GoodEntryController {
    * @param entry The PoG ID of the entry
    * @returns A Proof of Good Entry
    */
-  @post('/entry', {
+  @post('/', {
     summary: 'Create a GoodEntry',
     operationId: 'post-pog-entry',
     responses: {

--- a/src/controllers/oracle.controller.ts
+++ b/src/controllers/oracle.controller.ts
@@ -3,6 +3,7 @@ import {authorize} from '@loopback/authorization';
 import {inject, service} from '@loopback/core';
 import {Filter, repository} from '@loopback/repository';
 import {
+  api,
   get,
   getModelSchemaRef,
   HttpErrors,
@@ -19,6 +20,7 @@ import {AUTH_STRATEGY_NAME} from '../providers/passport-bearer-auth.provider';
 import {GoodOracleRepository} from '../repositories';
 import {ProofOfGoodSmartContractService} from '../services';
 
+@api({basePath: '/oracle'})
 @authenticate(AUTH_STRATEGY_NAME)
 @authorize({resource: 'oracle'})
 export class OracleController {
@@ -36,7 +38,7 @@ export class OracleController {
    *
    * @param oracle
    */
-  @post('/oracle', {
+  @post('/', {
     summary: 'Create an Oracle',
     operationId: 'post-oracle',
     responses: {
@@ -149,7 +151,7 @@ export class OracleController {
    * @param id The PoG ID of the oracle
    * @returns A Proof of Good Oracle
    */
-  @get('/oracle/{id}', {
+  @get('/{id}', {
     summary: 'Get Oracle',
     operationId: 'get-oracle',
     responses: {
@@ -203,7 +205,7 @@ export class OracleController {
     return this.goodOracleRepository.findById(id);
   }
 
-  @get('/oracle', {
+  @get('/', {
     responses: {
       '200': {
         description: 'Retrieve all Proof of Good Oracles',
@@ -232,7 +234,7 @@ export class OracleController {
    * @param id The ID of the oracle
    * @param oracle
    */
-  @patch('/oracle/{id}', {
+  @patch('/{id}', {
     summary: 'Change Oracle Details',
     operationId: 'patch-oracle',
     responses: {
@@ -376,7 +378,7 @@ export class OracleController {
    * @param id The PoG ID of the oracle
    * @param oracle
    */
-  @put('/oracle/{id}', {
+  @put('/{id}', {
     summary: 'Change Oracle Details',
     operationId: 'put-oracle',
     responses: {
@@ -458,7 +460,7 @@ export class OracleController {
    *
    * @param oracle
    */
-  @post('/oracle/cap', {
+  @post('/cap', {
     summary: 'Set Oracle cap',
     operationId: 'post-oracle-cap',
     responses: {

--- a/src/controllers/profile.controller.ts
+++ b/src/controllers/profile.controller.ts
@@ -2,13 +2,14 @@ import {authenticate} from '@loopback/authentication';
 import {authorize} from '@loopback/authorization';
 import {inject, service} from '@loopback/core';
 import {repository} from '@loopback/repository';
-import {get, param, post, requestBody} from '@loopback/rest';
+import {api, get, param, post, requestBody} from '@loopback/rest';
 import {SecurityBindings} from '@loopback/security';
 import {GoodOracle, PogProfile} from '../models';
 import {AUTH_STRATEGY_NAME} from '../providers/passport-bearer-auth.provider';
 import {PogProfileRepository} from '../repositories';
 import {ProofOfGoodSmartContractService} from '../services';
 
+@api({basePath: '/profile'})
 export class ProfileController {
   constructor(
     @repository(PogProfileRepository)
@@ -21,7 +22,7 @@ export class ProfileController {
 
   @authenticate(AUTH_STRATEGY_NAME)
   @authorize({resource: 'SYSTEM_ONLY'})
-  @post('/profile/consolidate')
+  @post('/consolidate')
   async merge(
     @requestBody({
       content: {
@@ -132,7 +133,7 @@ export class ProfileController {
     return {};
   }
 
-  @get('/profile/{id}/points')
+  @get('/{id}/points')
   async getUserGoodPoints(
     @param({
       schema: {

--- a/src/controllers/type.controller.ts
+++ b/src/controllers/type.controller.ts
@@ -1,6 +1,7 @@
 import {service} from '@loopback/core';
 import {Filter, repository} from '@loopback/repository';
 import {
+  api,
   get,
   getModelSchemaRef,
   HttpErrors,
@@ -14,6 +15,7 @@ import {ErrorResponse, GoodType} from '../models';
 import {GoodTypeRepository} from '../repositories';
 import {ProofOfGoodSmartContractService} from '../services';
 
+@api({basePath: '/type'})
 export class GoodTypeController {
   constructor(
     @repository(GoodTypeRepository)
@@ -22,7 +24,7 @@ export class GoodTypeController {
     private proofOfGoodSmartContractService: ProofOfGoodSmartContractService,
   ) {}
 
-  @post('/type', {
+  @post('/', {
     summary: 'Create a Good Type',
     operationId: 'post-good-type',
     responses: {
@@ -115,7 +117,7 @@ export class GoodTypeController {
     } as GoodType);
   }
 
-  @patch('/type/{id}', {
+  @patch('/{id}', {
     summary: 'Update a Good Type',
     operationId: 'patch-good-type',
     responses: {
@@ -238,7 +240,7 @@ export class GoodTypeController {
       });
   }
 
-  @put('/type/{id}', {
+  @put('/{id}', {
     summary: 'Change Good Type Details',
     operationId: 'put-good-type',
     responses: {
@@ -322,7 +324,7 @@ export class GoodTypeController {
     return this.patchGoodType(id, goodType);
   }
 
-  @get('/type/{id}', {
+  @get('/{id}', {
     summary: 'Get Good Type',
     operationId: 'get-good-type',
     responses: {
@@ -374,7 +376,7 @@ export class GoodTypeController {
     return this.goodTypeRepository.findById(id);
   }
 
-  @get('/type', {
+  @get('/', {
     responses: {
       '200': {
         description: 'Retrieve all Proof of Good Categories',

--- a/src/models/oracle-api-key.model.ts
+++ b/src/models/oracle-api-key.model.ts
@@ -56,7 +56,7 @@ export class OracleApiKey extends Entity {
       default: false,
     },
   })
-  expired: boolean;
+  expired: boolean = false;
 }
 
 export interface OracleApiKeyRelations {


### PR DESCRIPTION
- implements `@api({basePath})` on all controllers
- consolidates authentication annotation in AuthController
- `/refresh` endpoint now becomes `/auth/refresh`
- set `OracleApiKey#expired` to initialize to false, as the missing entity property was causing an error with the authorization verifyFn